### PR TITLE
Add onExpr method to Query class

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -172,6 +172,24 @@ class Query extends Base
     }
 
     /**
+     * @param $expression
+     *
+     * @return $this
+     * @throws InvalidArgumentException
+     */
+    public function onExpr($expression)
+    {
+        if (!is_string($expression)) {
+            throw new InvalidArgumentException('$expression argument must be a string');
+        }
+
+        $joinStr = sprintf(' ON %s', $expression);
+        $this->combineQueryStr($joinStr);
+
+        return $this;
+    }
+
+    /**
      * @param $column
      * @param $condition
      * @param $value


### PR DESCRIPTION
This will allow us to use expressions as the condition when joining on tables, whereas the regular on method of the query requires a left col, condition, and right col.